### PR TITLE
Revised CoroutineOrExecutorMapper

### DIFF
--- a/aiopyramid/config.py
+++ b/aiopyramid/config.py
@@ -96,7 +96,7 @@ class CoroutineOrExecutorMapper(AsyncioMapperBase):
             asyncio.iscoroutinefunction(original) or
             is_generator(original) or
             is_generator(
-                getattr(original, '__call__', None)
+                getattr(original, self.attr, None)
             )
         ):
             view = asyncio.coroutine(view)


### PR DESCRIPTION
CoroutineOrExecutorMapper should check the Class Based View's request method, not necessarily __call__.